### PR TITLE
Fix scheduled workflow token handling

### DIFF
--- a/.github/workflows/chatkit-js-upstream-check.yml
+++ b/.github/workflows/chatkit-js-upstream-check.yml
@@ -22,13 +22,13 @@ jobs:
           fetch-depth: 0
 
       - name: Clone upstream chatkit-js
-        run: git clone https://github.com/openai/chatkit-js.git "$GITHUB_WORKSPACE/_upstream/chatkit-js"
+        run: git clone https://github.com/openai/chatkit-js.git "$RUNNER_TEMP/chatkit-js-upstream"
 
       - name: Check upstream translation state
         id: check
         shell: pwsh
         run: |
-          $output = & ./tools/upstream-sync/Invoke-UpstreamSync.ps1 -CheckOnly -UpstreamPath "$env:GITHUB_WORKSPACE/_upstream/chatkit-js" 2>&1
+          $output = & ./tools/upstream-sync/Invoke-UpstreamSync.ps1 -CheckOnly -UpstreamPath "$env:RUNNER_TEMP/chatkit-js-upstream" 2>&1
           if ($LASTEXITCODE -ne 0) {
             $output
             exit $LASTEXITCODE

--- a/.github/workflows/chatkit-runtime-upstream-sync.yml
+++ b/.github/workflows/chatkit-runtime-upstream-sync.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Create pull request
         uses: peter-evans/create-pull-request@v8.1.0
         with:
+          token: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           branch: bot/chatkit-runtime-upstream-sync
           delete-branch: true
           title: Sync ChatKit runtime from @openai/chatkit-react

--- a/.github/workflows/notice-daily-check.yml
+++ b/.github/workflows/notice-daily-check.yml
@@ -42,6 +42,7 @@ jobs:
         if: steps.notice_diff.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/notice-refresh
           delete-branch: true
           commit-message: "chore: refresh NOTICE.md"

--- a/.github/workflows/workbench-import-issues-pr.yml
+++ b/.github/workflows/workbench-import-issues-pr.yml
@@ -81,6 +81,7 @@ jobs:
         if: steps.import_diff.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/workbench-import-issues
           delete-branch: true
           commit-message: "chore: import GitHub issues into workbench items"


### PR DESCRIPTION
Fix the scheduled workflow failures in ChatKit dotnet.

- Route create-pull-request through WORKBENCH_GITHUB_TOKEN fallback.
- Move the ChatKit JS upstream clone out of the repository working tree so the check step no longer sees a dirty tree.

Validation: git diff --check.