### PR TITLE
Fix scheduled Workbench issue import

### DIFF
--- a/.github/workflows/workbench-import-issues-pr.yml
+++ b/.github/workflows/workbench-import-issues-pr.yml
@@ -62,9 +62,9 @@ jobs:
         shell: bash
         run: |
           if [ -x ./.tools/workbench ]; then
-            ./.tools/workbench item sync -- --import-issues
+            ./.tools/workbench sync --items --import-issues
           else
-            dotnet tool run workbench -- item sync -- --import-issues
+            dotnet tool run workbench -- sync --items --import-issues
           fi
 
       - name: Detect imported issue changes


### PR DESCRIPTION
## What changed

Use `workbench sync --items --import-issues` for the scheduled bulk import in both executable paths.

## Root cause

The copied workflow invoked an unsupported single-item command shape; all historical runs failed before synchronization.

## Validation

Exact pinned Workbench help, workflow YAML parsing, and `git diff --check` passed.